### PR TITLE
Add missing build and test dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel": "^5.8.20",
     "babel-core": "^5.8.20",
     "babel-loader": "^5.3.2",
+    "chai": "^3.2.0",
     "karma": "^0.13.3",
     "karma-coverage": "^0.4.2",
     "karma-mocha": "^0.2.0",
@@ -37,6 +38,9 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.2.5",
     "phantomjs": "^1.9.17",
+    "sinon": "^1.15.4",
+    "sinon-chai": "^2.8.0",
+    "uglifyjs": "^2.4.10",
     "webpack": "^1.10.5"
   },
   "scripts": {


### PR DESCRIPTION
The uglifyjs and sinon-chai modules are required for building the
project and running tests but were missing from the devDependencies.

The peerDependencies of sinon and chai are also added as top level
dependencies so that the project can be installed using npm v3.
