### PR TITLE
Ignore npm-debug.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 dist
 build
+npm-debug.log


### PR DESCRIPTION
This file will be created whenever an error occurs while using npm, but
we never want it to be committed to the project.
