### PR TITLE
Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+
+script:
+  - npm test
+
+notifications:
+  email: false
+
+branches:
+  except:
+  - /^v\d+\.\d+\.\d+$/


### PR DESCRIPTION
The node/iojs version is automatically sourced from `.nvmrc`.
