### PR TITLE
Promise is configurable on Client

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -6,3 +6,12 @@ export function isFunction(val) {
     throw new TypeError(`Expecting function, got ${type}`);
   }
 }
+
+export function exists(val) {
+  if (typeof val === 'undefined') {
+    throw new TypeError('Value must exist, cannot be undefined');
+  }
+  if (val === null) {
+    throw new TypeError('Value must exist, cannot be null');
+  }
+}

--- a/lib/client.js
+++ b/lib/client.js
@@ -6,10 +6,12 @@ import * as assert from '../lib/assert';
 const $request = Symbol('request');
 
 export class Client {
-  constructor({ url, token, request } = {}) {
+  constructor({ url, token, request, Promise }) {
     assert.isFunction(request);
+    assert.exists(Promise);
 
     this[$request] = request;
+    this.Promise = Promise;
   }
 
   collections(arr) {
@@ -44,6 +46,6 @@ export class Client {
 
     const requestArgs = { method, url, body, params, headers };
     const request = this[$request](requestArgs);
-    return new Response(request, this.Promise); // todo: make Promise be something
+    return new Response(request, this.Promise);
   }
 }

--- a/test/assert.spec.js
+++ b/test/assert.spec.js
@@ -14,4 +14,19 @@ describe('assert', () => {
       expect(() => assert.isFunction(arg)).not.to.throw();
     })
   });
+
+  describe('#exists', () => {
+    it('throws if value is undefined', () => {
+      expect(() => assert.exists()).to.throw();
+    });
+    it('throws if value is null', () => {
+      expect(() => assert.exists(null)).to.throw();
+    });
+    it('noops if arg exists', () => {
+      expect(() => assert.exists('')).not.to.throw();
+      expect(() => assert.exists(0)).not.to.throw();
+      expect(() => assert.exists([])).not.to.throw();
+      expect(() => assert.exists({})).not.to.throw();
+    });
+  });
 });


### PR DESCRIPTION
Rather than bundle a Promise implementation in the core library, the
client constructor requires the consumer to pass a promise constructor.
Client developers can then decide to bundle a specific promise
implementation with their api client or leave it up to the end user.
