### PR TITLE
fetchAll should be filter-aware

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -36,10 +36,15 @@ export function isFunction(val) {
   }
 }
 
-export function exists(val) {
+export function isDefined(val) {
   if (typeof val === 'undefined') {
-    throw new TypeError('Value must exist, cannot be undefined');
+    throw new TypeError('Cannot be undefined');
   }
+}
+
+export function exists(val) {
+  isDefined(val);
+
   if (val === null) {
     throw new TypeError('Value must exist, cannot be null');
   }

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -2,6 +2,7 @@
 
 import { View } from './view';
 import { Filter } from './collection/filter';
+import { Filters } from './collection/filters';
 
 const $filters = Symbol('filters');
 const $modelName = Symbol('model');
@@ -14,7 +15,7 @@ export class Collection extends Map {
   constructor(client) {
     super();
     this[$client] = client;
-    this[$filters] = [];
+    this[$filters] = new Filters();
     this[$view] = View;
     this[$views] = new Map();
 
@@ -27,7 +28,7 @@ export class Collection extends Map {
 
   filter(name, fn) {
     const filter = new Filter(name, fn);
-    this[$filters].push(filter);
+    this[$filters].add(filter);
   }
 
   modelName(name) {
@@ -76,6 +77,7 @@ export class Collection extends Map {
   }
 
   $rawFetchAll(params={}) {
+    this[$filters].assertHasAll(Object.keys(params));
     let execRequest = this.client.request(this.pluralRequest());
     return execRequest(params);
   }
@@ -100,6 +102,7 @@ export class Collection extends Map {
   }
 
   findAll(params={}) {
+    // todo: do we have a view that includes filters for each of these params (and no others)?
     if (!this[$views].has(params)) {
       let CollectionView = this.view();
       let promise = this.$rawFetchAll(params).$body();

--- a/lib/collection/filter.js
+++ b/lib/collection/filter.js
@@ -1,19 +1,19 @@
 'use strict';
 
 const $callback = Symbol('callback');
-const $name = Symbol('name');
+const $identity = Symbol('identity');
 
 export class Filter {
-  constructor(name, callback) {
+  constructor(identity, callback) {
     this[$callback] = callback;
-    this[$name] = name;
+    this[$identity] = identity;
   }
 
   get callback() {
     return this[$callback];
   }
 
-  get name() {
-    return this[$name];
+  get identity() {
+    return this[$identity];
   }
 };

--- a/lib/collection/filter.js
+++ b/lib/collection/filter.js
@@ -1,10 +1,15 @@
 'use strict';
 
+import * as assert from '../assert';
+
 const $callback = Symbol('callback');
 const $identity = Symbol('identity');
 
 export class Filter {
   constructor(identity, callback) {
+    assert.isDefined(identity);
+    assert.isFunction(callback);
+
     this[$callback] = callback;
     this[$identity] = identity;
   }

--- a/lib/collection/filters.js
+++ b/lib/collection/filters.js
@@ -1,0 +1,18 @@
+'use strict';
+
+import { IdentityMap } from './util/identity-map';
+import { isArray } from './util/type-checks';
+
+export class Filters extends IdentityMap {
+  hasAll(identities) {
+    return identities.every(i => this.has(i));
+  }
+
+  assertHasAll(identities) {
+    if (!this.hasAll(identities)) {
+      const missingFilters = identities.filter(i => !this.has(i));
+      const missing = missingFilters.join(', ');
+      throw new Error(`Some filters were not configured: ${missing}`);
+    }
+  }
+}

--- a/lib/util/identity-map.js
+++ b/lib/util/identity-map.js
@@ -1,0 +1,25 @@
+'use strict';
+
+import * as assert from '../assert';
+
+class IdentityMap extends Map {
+  add(obj) {
+    assert.isFunction(obj.identity);
+
+    super.set(obj.identity(), obj);
+    return this;
+  }
+
+  remove(obj) {
+    super.delete(obj.identity());
+    return this;
+  }
+
+  set() {
+    throw new Error('Cannot `set` on IdentityMap. Use `add` instead.');
+  }
+
+  delete() {
+    throw new Error('Cannot `delete` on IdentityMap. Use `remove` instead.');
+  }
+}

--- a/lib/util/type-checks.js
+++ b/lib/util/type-checks.js
@@ -1,0 +1,5 @@
+'use strict';
+
+export function isArray(val) {
+  return val instanceof Array;
+}

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "transpile": "babel lib --out-dir build",
     "build": "webpack && npm run minify",
     "minify": "uglifyjs dist/jsclient.js -o dist/jsclient.min.js",
-    "test-browser": "karma start ./karma.config.js",
-    "test-node": "mocha --compilers js:babel/register -r test/setup/index-node"
+    "test-browser": "karma start test/setup/karma.config.js",
+    "test-node": "mocha --opts test/setup/mocha.opts test/*.spec.js test/**/*.spec.js"
   }
 }

--- a/test/assert.spec.js
+++ b/test/assert.spec.js
@@ -3,15 +3,36 @@
 import * as assert from '../lib/assert';
 
 describe('assert', () => {
-  describe('#isFunction', () => {
-    it('throws error if arg is not a function', () => {
-      expect(() => assert.isFunction()).to.throw();
-      expect(() => assert.isFunction('foo')).to.throw();
-      expect(() => assert.isFunction({})).to.throw();
+  describe('#isFunction()', () => {
+    context('when given a non-function', () => {
+      it('throws', () => {
+        expect(() => assert.isFunction()).to.throw();
+        expect(() => assert.isFunction('foo')).to.throw();
+        expect(() => assert.isFunction({})).to.throw();
+      });
     })
-    it('noops if arg is a function', () => {
-      const arg = () => {};
-      expect(() => assert.isFunction(arg)).not.to.throw();
+
+    context('when given a function', () => {
+      it('does not throw', () => {
+        const arg = () => {};
+        expect(() => assert.isFunction(arg)).not.to.throw();
+      });
+    })
+  });
+
+  describe('#isDefined()', () => {
+    context('when given undefined', () => {
+      it('throws', () => {
+        expect(() => assert.isDefined()).to.throw();
+      });
+    })
+
+    context('when given a defined value', () => {
+      it('does not throw', () => {
+        expect(() => assert.isDefined(0)).not.to.throw();
+        expect(() => assert.isDefined(null)).not.to.throw();
+        expect(() => assert.isDefined('')).not.to.throw();
+      });
     })
   });
 

--- a/test/collection/filter.spec.js
+++ b/test/collection/filter.spec.js
@@ -1,0 +1,59 @@
+'use strict';
+
+import { Filter } from '../../lib/collection/filter';
+
+let identity;
+let callback;
+let filter;
+
+describe('Filter', () => {
+  beforeEach(() => {
+    identity = 123;
+    callback = function() {};
+  });
+
+  describe('constructor', () => {
+    context('when identity is defined', () => {
+      it('sets #identity', () => {
+        filter = new Filter(identity, callback);
+        expect(filter.identity).to.equal(identity);
+      })
+    })
+
+    context('when identity is undefined', () => {
+      it('throws', () => {
+        expect(() => new Filter(undefined, callback)).to.throw();
+      })
+    })
+
+    context('when callback is not function', () => {
+      it('throws', () => {
+        expect(() => new Filter(identity)).to.throw();
+        expect(() => new Filter(identity, {})).to.throw();
+      })
+    })
+
+    context('when callback is a function', () => {
+      it('sets #callback', () => {
+        filter = new Filter(identity, callback);
+        expect(filter.callback).to.equal(callback);
+      });
+    })
+  })
+
+  describe('#identity', () => {
+    it('is readonly', () => {
+      filter = new Filter(identity, callback);
+      expect(filter.identity).to.equal(identity);
+      expect(() => filter.identity = 'foo').to.throw();
+    })
+  })
+
+  describe('#callback', () => {
+    it('is readonly', () => {
+      filter = new Filter(identity, callback);
+      expect(filter.callback).to.equal(callback);
+      expect(() => filter.callback = function() {}).to.throw();
+    })
+  })
+});

--- a/test/setup/index-browser.js
+++ b/test/setup/index-browser.js
@@ -3,6 +3,6 @@
 //
 // http://nicolasgallagher.com/how-to-test-react-components-karma-webpack/
 
-var context = require.context('../', false, /.+\.spec\.js?$/);
+var context = require.context('../', true, /.+\.spec\.js?$/);
 context.keys().forEach(context);
 module.exports = context;

--- a/test/setup/karma.config.js
+++ b/test/setup/karma.config.js
@@ -1,8 +1,10 @@
 var _ = require('lodash'),
-  webpackConfig = require('./webpack.config');
+  path = require('path'),
+  webpackConfig = require('../../webpack.config');
 
 module.exports = function(config) {
   config.set({
+    basePath: path.join(__dirname, '..', '..'),
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,

--- a/test/setup/mocha.opts
+++ b/test/setup/mocha.opts
@@ -1,0 +1,2 @@
+--compilers js:babel/register
+-r test/setup/index-node


### PR DESCRIPTION
An error is thrown when a user tries to fetch data through a collection
with parameters that were not configured as filters in advance.

This PR introduces a standard IdentityMap class that really should be
used elsewhere as well (ie Collection), but I'll do that in a followup PR.

The type checks throughout the project should also be moved to the new
type-check module in a future PR.
