### PR TITLE
Collections manage filters to create views

### DIFF
--- a/example/collections/accounts.js
+++ b/example/collections/accounts.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import { Collection } from '../collection';
+import { Filter } from '../../lib/collection/filter';
 import { AccountsView } from '../views/accounts';
 
 export class Accounts extends Collection {
@@ -10,7 +11,38 @@ export class Accounts extends Collection {
 
     this.view(AccountsView); // optional, only necessary if you want a custom View
 
-    this.filter('perPage', (n=50) => `per_page=${n}`);
-    this.filter('page', (p=1) => `page=${p}`);
+    // todo: filters should be stored in individual files
+    this.filter('page', class PageFilter extends Filter {
+      matches(model, value) {
+        const first = this.view.first();
+        const last = this.view.last();
+        return model.created_at > first && model.created_at < last;
+      }
+    });
+
+    this.filter('per_page', class PerPageFilter extends Filter {
+      matches(model, size) {
+        return this.createdWithin(model) || this.canBeAppended(model, size);
+      }
+
+      canBeAppended(model, size) {
+        return this.createdAfter(model) && this.roomFor(size);
+      }
+
+      createdWithin(model) {
+        const first = this.view.first();
+        const last = this.view.last();
+        return model.created_at > first && model.created_at < last;
+      }
+
+      createdAfter(model) {
+        const last = this.view.last();
+        return model.created_at >= last;
+      }
+
+      roomFor(size) {
+        return this.view.size < size;
+      }
+    });
   }
 }

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1,8 +1,6 @@
 'use strict';
 
 import { View } from './view';
-import { Filter } from './collection/filter';
-import { Filters } from './collection/filters';
 
 const $filters = Symbol('filters');
 const $modelName = Symbol('model');
@@ -15,7 +13,7 @@ export class Collection extends Map {
   constructor(client) {
     super();
     this[$client] = client;
-    this[$filters] = new Filters();
+    this[$filters] = new Map();
     this[$view] = View;
     this[$views] = new Map();
 
@@ -26,9 +24,11 @@ export class Collection extends Map {
     return this[$client];
   }
 
-  filter(name, fn) {
-    const filter = new Filter(name, fn);
-    this[$filters].add(filter);
+  filter(name, Filter) {
+    if (Filter) {
+      this[$filters].set(name, Filter);
+    }
+    return this[$filters].get(name);
   }
 
   modelName(name) {
@@ -102,23 +102,28 @@ export class Collection extends Map {
   }
 
   findAll(params={}) {
-    // todo: do we have a view that includes filters for each of these params (and no others)?
-    if (!this[$views].has(params)) {
-      let CollectionView = this.view();
-      let promise = this.$rawFetchAll(params).$body();
-      let view = new CollectionView(promise, this, params);
-      this[$views].set(params, view);
+    const key = Object.keys(params).sort().join('.');
+    if (!this[$views].has(key)) {
+      const CollectionView = this.view();
+      const promise = this.$rawFetchAll(params).$body();
+      const view = new CollectionView(promise, this, params);
+      this[$views].set(key, view);
     }
-    return this[$views].get(params);
+    return this[$views].get(key);
+  }
+
+  syncWithViews(model) {
+    this[$views].forEach(view => {
+      if (view.needs(model)) {
+        view.add(model);
+      }
+    });
   }
 
   add(model) {
     // todo: add to any view of which this matches the filter(?)
     super.set(model.identity(), model);
-    this[$views].forEach(view => {
-      //if (this)
-
-    });
+    this.syncWithViews(model);
     return this;
   }
 

--- a/lib/collection/filter.js
+++ b/lib/collection/filter.js
@@ -1,24 +1,17 @@
 'use strict';
 
-import * as assert from '../assert';
-
-const $callback = Symbol('callback');
-const $identity = Symbol('identity');
+const $view = Symbol('view');
 
 export class Filter {
-  constructor(identity, callback) {
-    assert.isDefined(identity);
-    assert.isFunction(callback);
-
-    this[$callback] = callback;
-    this[$identity] = identity;
+  constructor(view) {
+    this[$view] = view;
   }
 
-  get callback() {
-    return this[$callback];
+  get view() {
+    return this[$view];
   }
 
-  get identity() {
-    return this[$identity];
+  matches() {
+    throw new Error('Not implemented');
   }
 };

--- a/lib/view.js
+++ b/lib/view.js
@@ -3,6 +3,7 @@
 const $loaded = Symbol('loaded');
 const $loading = Symbol('loading');
 const $params = Symbol('params');
+const $filters = Symbol('filters');
 const $reloading = Symbol('reloading');
 const $model = Symbol('model');
 const $plural = Symbol('plural');
@@ -13,6 +14,7 @@ export default class View extends Map {
     super();
     this[$collection] = collection;
     this[$params] = params;
+    this[$filters] = [];
     this[$loaded] = false;
     this[$reloading] = null;
     this[$model] = null;
@@ -21,6 +23,13 @@ export default class View extends Map {
       .then(resources => resources.map(this.collection.modelFactory))
       .then(fulfillModelPromises)
       .then(models => loadWithModels(this, models));
+
+    // set up view filters
+    Object.keys(this.params).forEach(param => {
+      const Filter = this.collection.filter(param);
+      const filter = new Filter(this);
+      this[$filters].push(filter);
+    });
 
     !this.init || this.init();
   }
@@ -50,7 +59,7 @@ export default class View extends Map {
   }
 
   $rawFetchAll() {
-    return this.collection.$rawFetchAll(this.params());
+    return this.collection.$rawFetchAll(this.params);
   }
 
   // reloads the current view
@@ -70,9 +79,20 @@ export default class View extends Map {
     return this;
   }
 
+  matches(model) {
+    // todo: $filters would need to be an array
+    return this[$filters].every(filter => filter.matches(model));
+  }
+
+  needs(model) {
+    return !this.has(model.identity()) && this.matches(model);
+  }
+
   add(model) {
-    this.collection.add(model);
     super.set(model.identity(), model);
+    if (!this.collection.has(model.identity())) {
+      this.collection.add(model);
+    }
     return this;
   }
 

--- a/test/collection/filter.spec.js
+++ b/test/collection/filter.spec.js
@@ -2,58 +2,30 @@
 
 import { Filter } from '../../lib/collection/filter';
 
-let identity;
-let callback;
+let view;
 let filter;
 
 describe('Filter', () => {
   beforeEach(() => {
-    identity = 123;
-    callback = function() {};
+    view = {};
+    filter = new Filter(view);
   });
 
   describe('constructor', () => {
-    context('when identity is defined', () => {
-      it('sets #identity', () => {
-        filter = new Filter(identity, callback);
-        expect(filter.identity).to.equal(identity);
-      })
-    })
-
-    context('when identity is undefined', () => {
-      it('throws', () => {
-        expect(() => new Filter(undefined, callback)).to.throw();
-      })
-    })
-
-    context('when callback is not function', () => {
-      it('throws', () => {
-        expect(() => new Filter(identity)).to.throw();
-        expect(() => new Filter(identity, {})).to.throw();
-      })
-    })
-
-    context('when callback is a function', () => {
-      it('sets #callback', () => {
-        filter = new Filter(identity, callback);
-        expect(filter.callback).to.equal(callback);
-      });
+    it('sets #view', () => {
+      expect(filter.view).to.equal(view);
     })
   })
 
-  describe('#identity', () => {
+  describe('#view', () => {
     it('is readonly', () => {
-      filter = new Filter(identity, callback);
-      expect(filter.identity).to.equal(identity);
-      expect(() => filter.identity = 'foo').to.throw();
+      expect(() => filter.view = {}).to.throw();
     })
   })
 
-  describe('#callback', () => {
-    it('is readonly', () => {
-      filter = new Filter(identity, callback);
-      expect(filter.callback).to.equal(callback);
-      expect(() => filter.callback = function() {}).to.throw();
+  describe('#matches()', () => {
+    it('throws by default (must be overwritten)', () => {
+      expect(filter.matches).to.throw();
     })
   })
 });


### PR DESCRIPTION
Params used to execute requests for Views can now have filters
associated with them. Filters are configured on Collections and are used
to filter results in a collection in memory as models are removed/added.

For #10 
